### PR TITLE
Replace multiple arguments with a bit vector

### DIFF
--- a/src/states/BaseState.cpp
+++ b/src/states/BaseState.cpp
@@ -86,7 +86,7 @@ void BaseState::renderBackground(StateMachine & machine, bool renderCorners) {
 
 }
 
-void BaseState::renderPlayerStatistics(StateMachine & machine, bool overallFlash, bool flashXP, bool flashHP, bool flashArmour, bool flashGold, bool flashFood) {
+void BaseState::renderPlayerStatistics(StateMachine & machine, bool overallFlash, FlashSettings settings){
 
 	auto & arduboy = machine.getContext().arduboy;
 	auto & playerStats = machine.getContext().playerStats;
@@ -106,27 +106,27 @@ void BaseState::renderPlayerStatistics(StateMachine & machine, bool overallFlash
 
       case 1:   
         val = playerStats.xp;       
-        flag = flashXP;
+        flag = ((settings & FlashSettings::FlashXP) != 0);
         break;
 
       case 2:   
         val = playerStats.hp;
-        flag = flashHP;
+        flag = ((settings & FlashSettings::FlashHP) != 0);
         break;
 
       case 3:   
         val = playerStats.armour;
-        flag = flashArmour;
+        flag = ((settings & FlashSettings::FlashArmour) != 0);
         break;
 
       case 4:   
         val = playerStats.gold;
-        flag = flashGold;
+        flag = ((settings & FlashSettings::FlashGold) != 0);
         break;
 
       case 5:   
         val = playerStats.food;
-        flag = flashFood;
+        flag = ((settings & FlashSettings::FlashFood) != 0);
         break;
 
     }

--- a/src/states/BaseState.h
+++ b/src/states/BaseState.h
@@ -18,7 +18,7 @@ class BaseState : public GameState<GameContext, GameStateType> {
     void renderLargeSpinningCard(StateMachine & machine, int8_t x, int8_t y, uint8_t i);
     void renderPlayerDead();
     void renderMonsterDead(StateMachine & machine);
-    void renderPlayerStatistics(StateMachine & machine, bool overallFlash, bool flashXP, bool flashHP, bool flashArmour, bool flashGold, bool flashFood);
+    void renderPlayerStatistics(StateMachine & machine, bool overallFlash, FlashSettings settings);
     void renderBackground(StateMachine & machine, bool renderCorners);
     void drawItem(uint8_t position, uint8_t const *imageName);
     void renderMessageBox(StateMachine & machine, uint8_t x, uint8_t y, uint8_t w, uint8_t h);

--- a/src/states/EventState.cpp
+++ b/src/states/EventState.cpp
@@ -143,17 +143,21 @@ void EventState::render(StateMachine & machine) {
 
   }
 
-
 	// Player statistics ..
 
-  BaseState::renderPlayerStatistics(machine,
-    (this->viewState == ViewState::UpdateStats && this->counter < FLASH_COUNTER), // Overall
-    (this->dice == 4), // XP
-    (this->dice == 2), // HP
-    (this->dice == 5), // Armour
-    (this->dice == 1), // Gold
-    (this->dice == 3) // Food
-  );
+	static const FlashSettings diceHelper[] PROGMEM =
+	{
+		FlashSettings::None,
+		FlashSettings::FlashGold,
+		FlashSettings::FlashHP,
+		FlashSettings::FlashFood,
+		FlashSettings::FlashXP,
+	};
+
+	const FlashSettings settings = (this->dice < 5) ? static_cast<FlashSettings>(pgm_read_byte(&diceHelper[this->dice])) : FlashSettings::None;
+	const bool shouldFlash = (this->viewState == ViewState::UpdateStats && this->counter < FLASH_COUNTER);
+
+	BaseState::renderPlayerStatistics(machine, shouldFlash, settings);
 
 }
 

--- a/src/states/FightMonstersState.cpp
+++ b/src/states/FightMonstersState.cpp
@@ -541,14 +541,9 @@ void FightMonstersState::render(StateMachine & machine) {
 
 	// Player statistics ..
 
-  BaseState::renderPlayerStatistics(machine,
-    true, // Overall
-    false, // XP
-    (this->viewState == ViewState::HighlightPlayerStats), // HP
-    false, // Armour
-    false, // Gold
-    false // Food
-  );
+	const FlashSettings settings = ((this->viewState == ViewState::HighlightPlayerStats) ? FlashSettings::FlashHP : FlashSettings::FlashHP);
+
+	BaseState::renderPlayerStatistics(machine, true, settings);
 
 
 	// Messages ..
@@ -565,21 +560,19 @@ void FightMonstersState::render(StateMachine & machine) {
 			
 		case ViewState::MonsterDead:
 		case ViewState::MonsterDead_Wait:
-			{
-				bool gold = (machine.getContext().gameState == GameStateType::BossMonster);
-				bool armour = gold && (this->diceMonster == 5);
+			if (this->viewState != ViewState::MonsterDead_Wait) {
 
-				if (this->viewState != ViewState::MonsterDead_Wait) {
-					BaseState::renderPlayerStatistics(machine,
-						true, 	// Overall
-						true, 	// XP
-						false, 	// HP
-						armour, // Armour
-						gold, 	// Gold
-						false 	// Food
-					);
+				FlashSettings settings = FlashSettings::FlashXP;
 
+				if(machine.getContext().gameState == GameStateType::BossMonster)
+				{
+					settings |= FlashSettings::FlashGold;
+
+					if(this->diceMonster == 5)
+						settings |= FlashSettings::FlashArmour;
 				}
+
+				BaseState::renderPlayerStatistics(machine, true, settings);
 
 			}
 

--- a/src/states/FightMonstersState.cpp
+++ b/src/states/FightMonstersState.cpp
@@ -541,7 +541,7 @@ void FightMonstersState::render(StateMachine & machine) {
 
 	// Player statistics ..
 
-	const FlashSettings settings = ((this->viewState == ViewState::HighlightPlayerStats) ? FlashSettings::FlashHP : FlashSettings::FlashHP);
+	const FlashSettings settings = ((this->viewState == ViewState::HighlightPlayerStats) ? FlashSettings::FlashHP : FlashSettings::None);
 
 	BaseState::renderPlayerStatistics(machine, true, settings);
 

--- a/src/states/MerchantState.cpp
+++ b/src/states/MerchantState.cpp
@@ -37,7 +37,7 @@ void MerchantState::update(StateMachine & machine) {
               this->errorNumber = 3;
             } 
             else {
-              this->flashFood = true; 
+              this->settings |= FlashSettings::FlashFood; 
               playerStats.incFood(1); 
               playerStats.decGold(1); 
             }   
@@ -53,7 +53,7 @@ void MerchantState::update(StateMachine & machine) {
               this->errorNumber = 3;
             } 
             else { 
-              this->flashHP = true; 
+              this->settings |= FlashSettings::FlashHP;
               playerStats.incHP(1); 
               playerStats.decGold(1);
             }   
@@ -69,7 +69,7 @@ void MerchantState::update(StateMachine & machine) {
               this->errorNumber = 3;
             } 
             else { 
-              this->flashHP = true; 
+              this->settings |= FlashSettings::FlashHP;
               playerStats.incHP(4); 
               playerStats.decGold(3); 
             }   
@@ -84,7 +84,7 @@ void MerchantState::update(StateMachine & machine) {
 
                 playerStats.items[this->selectedItem - 3]++; 
                 playerStats.decGold(8); 
-                flashGold = true;
+                this->settings |= FlashSettings::FlashGold;
 
               }
               else {
@@ -106,7 +106,7 @@ void MerchantState::update(StateMachine & machine) {
 
                 playerStats.incArmour(1); 
                 playerStats.decGold(6); 
-                flashArmour = true;
+                this->settings |= FlashSettings::FlashArmour;
 
               }
               else {
@@ -120,7 +120,10 @@ void MerchantState::update(StateMachine & machine) {
 
         }
 
-        if (flashHP || flashXP || flashFood || flashArmour) { flashGold = true; }
+		constexpr FlashSettings flashTest = (FlashSettings::FlashHP | FlashSettings::FlashXP | FlashSettings::FlashFood| FlashSettings::FlashArmour);
+
+		if ((this->settings & flashTest) != FlashSettings::None)
+			this->settings |= FlashSettings::FlashGold;
 
       }
 
@@ -139,7 +142,7 @@ void MerchantState::update(StateMachine & machine) {
 
             playerStats.items[this->selectedItem]--;
             playerStats.incGold(4);
-            flashGold = true;
+            this->settings |= FlashSettings::FlashGold;
 
           }
           else {
@@ -153,8 +156,7 @@ void MerchantState::update(StateMachine & machine) {
 
             playerStats.decArmour(1);
             playerStats.incGold(3);
-            flashGold = true;
-            flashArmour = true;
+            this->settings |= (FlashSettings::FlashGold | FlashSettings::FlashArmour);
 
           }
           else {
@@ -243,13 +245,6 @@ void MerchantState::render(StateMachine & machine) {
 
   }
 
-  BaseState::renderPlayerStatistics(machine,
-    true, // Overall
-    flashXP, // XP
-    flashHP, // HP
-    flashArmour, // Armour
-    flashGold, // Gold
-    flashFood // Food
-  );
+  BaseState::renderPlayerStatistics(machine, true, this->settings);
 
 }

--- a/src/states/MerchantState.h
+++ b/src/states/MerchantState.h
@@ -28,13 +28,8 @@ class MerchantState : public BaseState {
     
     uint8_t selectedItem = 0;
     uint8_t errorNumber = 0;
-    
-    bool flashXP = false;
-    bool flashHP = false;
-    bool flashGold = false;
-    bool flashFood = false;
-    bool flashArmour = false;
 
+    FlashSettings settings;
 
   public:
 

--- a/src/states/RestingState.cpp
+++ b/src/states/RestingState.cpp
@@ -93,14 +93,25 @@ void RestingState::render(StateMachine & machine) {
 
 	// Player statistics ..
 
-  BaseState::renderPlayerStatistics(machine,
-    (this->viewState == ViewState::UpdateStats), // Overall
-    (this->selectedItem == SelectedItem::Weapon), // XP
-    (this->selectedItem == SelectedItem::Heal), // HP
-    false, // Armour
-    false, // Gold
-    (this->selectedItem == SelectedItem::Food) // Food
-  );
+	static_assert(SelectedItem::Food == static_cast<SelectedItem>(0), "SelectedItem enum changed, please update the settingsHelper array.");
+	static_assert(SelectedItem::Heal == static_cast<SelectedItem>(1), "SelectedItem enum changed, please update the settingsHelper array.");
+	static_assert(SelectedItem::Weapon == static_cast<SelectedItem>(2), "SelectedItem enum changed, please update the settingsHelper array.");
+
+	static const FlashSettings settingsHelper[] PROGMEM = 
+	{
+		//SelectedItem::Food
+		FlashSettings::FlashFood,
+		//SelectedItem::Heal
+		FlashSettings::FlashHP,
+		//SelectedItem::Weapon
+		FlashSettings::FlashXP,
+	};
+
+	const uint8_t index = static_cast<uint8_t>(this->selectedItem);
+	const FlashSettings settings = static_cast<FlashSettings>(pgm_read_byte(&settingsHelper[index]));
+	const bool shouldFlash = (this->viewState == ViewState::UpdateStats);
+
+	BaseState::renderPlayerStatistics(machine, shouldFlash, settings);
 
   if (flash) {
 

--- a/src/states/ShowCardsState.cpp
+++ b/src/states/ShowCardsState.cpp
@@ -157,14 +157,9 @@ void ShowCardsState::render(StateMachine & machine) {
 
 	// Player statistics ..
 
-  BaseState::renderPlayerStatistics(machine,
-    true,  // Overall
-    false, // XP
-    false, // HP
-    false, // Armour
-    false, // Gold
-    (viewState == ViewState::PlayerDead)  // Food
-  );
+	const FlashSettings settings = ((viewState == ViewState::PlayerDead) ? FlashSettings::FlashFood : FlashSettings::None);
+
+	BaseState::renderPlayerStatistics(machine, true, settings);
 
   const bool flash = arduboy.getFrameCountHalf(12);
 

--- a/src/states/TrapState.cpp
+++ b/src/states/TrapState.cpp
@@ -234,17 +234,22 @@ void TrapState::render(StateMachine & machine) {
 
   }
 
+  static const FlashSettings diceHelper[] PROGMEM =
+  {
+	FlashSettings::None,
+	FlashSettings::FlashFood,
+	FlashSettings::FlashGold,
+	FlashSettings::FlashArmour,
+	FlashSettings::FlashHP,
+	FlashSettings::FlashXP,
+  };
 
 	// Player statistics ..
 
-  BaseState::renderPlayerStatistics(machine,
-    (this->viewState == ViewState::UpdateStats && this->counter < FLASH_COUNTER), // Overall
-    (this->dice == 5), // XP
-    (this->dice == 4), // HP
-    (this->dice == 3), // Armour
-    (this->dice == 2), // Gold
-    (this->dice == 1) // Food
-  );
+	const FlashSettings settings = (this->dice < 6) ? static_cast<FlashSettings>(pgm_read_byte(&diceHelper[this->dice])) : FlashSettings::None;
+	const bool shouldFlash = (this->viewState == ViewState::UpdateStats && this->counter < FLASH_COUNTER);
+
+	BaseState::renderPlayerStatistics(machine, shouldFlash, settings);
 
 }
 

--- a/src/states/TreasureState.cpp
+++ b/src/states/TreasureState.cpp
@@ -189,14 +189,18 @@ void TreasureState::render(StateMachine & machine) {
 
 	// Player statistics ..
 
-  BaseState::renderPlayerStatistics(machine,
-    (this->viewState == ViewState::UpdateStats && this->counter < FLASH_COUNTER), // Overall
-    (this->dice == 6), // XP
-    (this->foundTreasure && this->dice == 4), // HP
-    (this->dice == 5), // Armour
-    true, // Gold
-    false // Food
-  );
+	FlashSettings settings = FlashSettings::FlashGold;
+
+	if(this->dice == 6)
+		settings |= FlashSettings::FlashXP;
+	else if(this->dice == 5)
+		settings|= FlashSettings::FlashArmour;
+	else if(this->dice == 4 && this->foundTreasure)
+		settings|= FlashSettings::FlashHP;
+
+	const bool shouldFlash = (this->viewState == ViewState::UpdateStats && this->counter < FLASH_COUNTER);
+
+	BaseState::renderPlayerStatistics(machine, shouldFlash, settings);
 
   if (this->viewState == ViewState::UpdateStats && this->foundTreasure && this->counter < FLASH_COUNTER && flash) {
 


### PR DESCRIPTION
(-222/0) Replaces multiple bool arguments with a scoped enumeration that acts as a bit vector.

After a certain number of arguments, a function call has to start placing data on the stack instead of in registers.
Using bit flags represented by a scoped enumeration reduces the parameter numbers and allows fewer registers to be used.
It also allows fewer registers to be occupied within the code that calculates the parameters.
In addition there are now fewer assignment operations required.
Fewer assignments is especially useful for mutually exclusive cases, as each branch now has a single assignment.